### PR TITLE
Support full connection string via command-line argument and interactive prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,13 @@ Run the following command from a command prompt such as Powershell:
 xperience-anonymizer
 ```
 
-The tool will prompt you to provide connection details for the Kentico database, then run the anonymization process.
+The tool will prompt you to provide connection details for the Kentico database, then run the anonymization process. You can either enter the individual connection fields (data source, user, password) when prompted, or provide a full SQL connection string — either via the interactive prompt or by passing it as a command-line argument:
+
+```powershell
+xperience-anonymizer --connection-string "Server=.;Database=MyDb;User Id=sa;Password=***"
+```
+
+The `-c` short form is also supported. If the connection string already contains an `Initial Catalog`/`Database`, the database selection prompt is skipped.
 
 ## Full Instructions
 

--- a/docs/Usage-Guide.md
+++ b/docs/Usage-Guide.md
@@ -1,5 +1,40 @@
 # Usage Guide
 
+## Providing connection details
+
+When you run `xperience-anonymizer`, you can provide database connection details in one of two ways:
+
+### Interactive prompts
+
+Run the tool with no arguments:
+
+```powershell
+xperience-anonymizer
+```
+
+You will be prompted to choose between:
+
+- **Full connection string** — paste a complete SQL connection string (input is masked).
+- **Individual fields** — enter the data source, user ID, and password separately. The tool will then list the available databases on the server for you to pick from.
+
+### Command-line argument
+
+You can skip the connection prompts by passing a full connection string as an argument:
+
+```powershell
+xperience-anonymizer --connection-string "Server=.;Database=MyDb;User Id=sa;Password=***"
+```
+
+Supported forms:
+
+- `--connection-string <value>`
+- `--connection-string=<value>`
+- `-c <value>`
+
+If the connection string includes an `Initial Catalog` (or `Database`), the database selection prompt is skipped. Otherwise, the tool will list the available databases on the server for you to pick from.
+
+> **Note:** A connection string passed on the command line may be visible in your shell history and process listings. Prefer the interactive prompt (which masks input) when running against sensitive environments.
+
 ## Supported tables
 
 See [`TablesConfiguration`](/src/Models/TablesConfiguration.cs) for a full list of supported tables and columns. The list can be customized using [this guide](#adding-your-tables).
@@ -38,11 +73,8 @@ For example, you may want to anonymize data entered in your forms:
   "Tables": [
     {
       "TableName": "DancingGoat_ContactUs",
-      "AnonymizeColumns": [
-        "Name",
-        "Email",
-      ]
-    },
+      "AnonymizeColumns": ["Name", "Email"]
+    }
     // Other tables...
   ]
 }

--- a/src/App.cs
+++ b/src/App.cs
@@ -22,7 +22,12 @@ namespace XperienceCommunity.DatabaseAnonymizer
         /// <summary>
         /// Runs the console application.
         /// </summary>
-        public async Task Run()
+        /// <param name="args">
+        /// Optional command-line arguments. Supports <c>--connection-string &lt;value&gt;</c>
+        /// (or <c>-c &lt;value&gt;</c>) to provide a full SQL connection string, bypassing
+        /// the individual connection prompts.
+        /// </param>
+        public async Task Run(string[]? args = null)
         {
             try
             {
@@ -30,7 +35,7 @@ namespace XperienceCommunity.DatabaseAnonymizer
                 AnsiConsole.Markup($"[{Constants.EMPHASIS_COLOR}]The anonymization process is irreversible! Please make sure you are" +
                     $" executing the process against a backup.[/]");
                 AnsiConsole.WriteLine();
-                var connectionSettings = GetConnectionSettings();
+                var connectionSettings = GetConnectionSettings(args);
                 anonymizerService.Anonymize(connectionSettings, tablesConfig);
             }
             catch (Exception ex)
@@ -41,14 +46,20 @@ namespace XperienceCommunity.DatabaseAnonymizer
         }
 
 
-        private static ConnectionSettings GetConnectionSettings()
+        private static ConnectionSettings GetConnectionSettings(string[]? args)
         {
-            var connectionSettings = new ConnectionSettings()
+            string? connectionStringArg = TryGetConnectionStringArg(args);
+            var connectionSettings = connectionStringArg is not null
+                ? new ConnectionSettings { ConnectionString = connectionStringArg }
+                : PromptConnectionSettings();
+
+            // If the database name is already provided (via connection string or individual prompts), skip selection.
+            if (!string.IsNullOrEmpty(connectionSettings.DatabaseName)
+                || !string.IsNullOrEmpty(connectionSettings.GetDatabaseFromConnectionString()))
             {
-                DataSource = AnsiConsole.Prompt(new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]Data source:[/] ")),
-                UserID = AnsiConsole.Prompt(new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]User ID:[/] ")),
-                Password = AnsiConsole.Prompt(new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]Password:[/] ") { IsSecret = true })
-            };
+                return connectionSettings;
+            }
+
             var databaseNames = GetDatabaseNames(connectionSettings);
             if (!databaseNames.Any())
             {
@@ -64,6 +75,68 @@ namespace XperienceCommunity.DatabaseAnonymizer
             AnsiConsole.Markup(databaseTitle + connectionSettings.DatabaseName);
 
             return connectionSettings;
+        }
+
+
+        private static ConnectionSettings PromptConnectionSettings()
+        {
+            const string connectionStringChoice = "Full connection string";
+            const string individualFieldsChoice = "Individual fields (data source, user, password)";
+            string mode = AnsiConsole.Prompt(new SelectionPrompt<string>()
+            {
+                Title = $"[{Constants.PROMPT_COLOR}]How would you like to provide connection details?[/]"
+            }.AddChoices(connectionStringChoice, individualFieldsChoice));
+
+            if (mode == connectionStringChoice)
+            {
+                string connectionString = AnsiConsole.Prompt(new TextPrompt<string>(
+                    $"[{Constants.PROMPT_COLOR}]Connection string:[/] ")
+                { IsSecret = true });
+                // Validate format early with a clear error message. Use the lenient base builder
+                // so keywords unknown to System.Data.SqlClient (e.g. "Command Timeout") are accepted.
+                _ = new System.Data.Common.DbConnectionStringBuilder { ConnectionString = connectionString };
+
+                return new ConnectionSettings { ConnectionString = connectionString };
+            }
+
+            return new ConnectionSettings()
+            {
+                DataSource = AnsiConsole.Prompt(new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]Data source:[/] ")),
+                UserID = AnsiConsole.Prompt(new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]User ID:[/] ")),
+                Password = AnsiConsole.Prompt(new TextPrompt<string>($"[{Constants.PROMPT_COLOR}]Password:[/] ") { IsSecret = true })
+            };
+        }
+
+
+        private static string? TryGetConnectionStringArg(string[]? args)
+        {
+            if (args is null || args.Length == 0)
+            {
+                return null;
+            }
+
+            for (int i = 0; i < args.Length; i++)
+            {
+                string arg = args[i];
+                if (string.Equals(arg, "--connection-string", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(arg, "-c", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (i + 1 >= args.Length)
+                    {
+                        throw new ArgumentException($"Missing value for '{arg}' argument.");
+                    }
+
+                    return args[i + 1];
+                }
+
+                const string inlinePrefix = "--connection-string=";
+                if (arg.StartsWith(inlinePrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return arg[inlinePrefix.Length..];
+                }
+            }
+
+            return null;
         }
 
 

--- a/src/Models/ConnectionSettings.cs
+++ b/src/Models/ConnectionSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.SqlClient;
+﻿using System.Data.Common;
+using System.Data.SqlClient;
 
 namespace XperienceCommunity.DatabaseAnonymizer.Models
 {
@@ -7,6 +8,13 @@ namespace XperienceCommunity.DatabaseAnonymizer.Models
     /// </summary>
     internal class ConnectionSettings
     {
+        /// <summary>
+        /// An optional full connection string. When set, it takes precedence over the individual properties,
+        /// except that any non-empty individual property will override the corresponding value in the string.
+        /// </summary>
+        public string? ConnectionString { get; set; }
+
+
         /// <summary>
         /// The data source.
         /// </summary>
@@ -37,28 +45,74 @@ namespace XperienceCommunity.DatabaseAnonymizer.Models
         /// </summary>
         public string ToConnectionString()
         {
-            var builder = new SqlConnectionStringBuilder();
+            // Parse with the lenient base builder so keywords unknown to System.Data.SqlClient
+            // (e.g. "Command Timeout") do not throw during parsing...
+            var parsed = new DbConnectionStringBuilder();
+            if (!string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                parsed.ConnectionString = ConnectionString;
+            }
+
             if (!string.IsNullOrEmpty(DataSource))
             {
-                builder.DataSource = DataSource;
+                parsed["Data Source"] = DataSource;
             }
 
             if (!string.IsNullOrEmpty(UserID))
             {
-                builder.UserID = UserID;
+                parsed["User ID"] = UserID;
             }
 
             if (!string.IsNullOrEmpty(Password))
             {
-                builder.Password = Password;
+                parsed["Password"] = Password;
             }
 
             if (!string.IsNullOrEmpty(DatabaseName))
             {
-                builder.InitialCatalog = DatabaseName;
+                parsed["Initial Catalog"] = DatabaseName;
             }
 
-            return builder.ConnectionString;
+            // ...then copy only keywords supported by System.Data.SqlClient, since Kentico uses
+            // that provider internally and will throw on unknown keywords when opening the connection.
+            var sqlBuilder = new SqlConnectionStringBuilder();
+            foreach (string key in parsed.Keys)
+            {
+                try
+                {
+                    sqlBuilder[key] = parsed[key];
+                }
+                catch (ArgumentException)
+                {
+                    // Silently drop keywords the SqlClient provider does not recognize
+                    // (e.g. "Command Timeout" is only supported by Microsoft.Data.SqlClient).
+                }
+            }
+
+            return sqlBuilder.ConnectionString;
+        }
+
+
+        /// <summary>
+        /// Returns the database name parsed from <see cref="ConnectionString"/>, if any.
+        /// </summary>
+        public string? GetDatabaseFromConnectionString()
+        {
+            if (string.IsNullOrWhiteSpace(ConnectionString))
+            {
+                return null;
+            }
+
+            var builder = new DbConnectionStringBuilder { ConnectionString = ConnectionString };
+            if (builder.TryGetValue("Initial Catalog", out var value)
+                || builder.TryGetValue("Database", out value))
+            {
+                string name = value.ToString() ?? string.Empty;
+
+                return string.IsNullOrEmpty(name) ? null : name;
+            }
+
+            return null;
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -20,4 +20,4 @@ builder.RegisterAssemblyTypes(assemblies)
 
 CMSApplication.PreInit();
 
-await builder.Build().Resolve<App>().Run();
+await builder.Build().Resolve<App>().Run(args);


### PR DESCRIPTION
# Motivation

Which issue does this fix? Fixes #7`

Previously the tool only accepted individual connection fields (data source, user ID, password) through interactive prompts, which is cumbersome for automation and doesn't support scenarios where users already have a full SQL connection string (for example from Kentico configuration, Azure portal, or CI/CD secrets).

This PR adds two ways to supply a full connection string:

1. **Command-line argument** — `--connection-string <value>`, `--connection-string=<value>`, or `-c <value>`. This enables non-interactive / scripted runs.
2. **Interactive selection** — at the first prompt users can choose between "Full connection string" (masked input) and the existing "Individual fields" flow.

Additional improvements:

- If the provided connection string already contains `Initial Catalog` (or `Database`), the database-selection prompt is skipped.
- Connection strings are parsed leniently (`DbConnectionStringBuilder`) so keywords like `Command Timeout` — which are valid in `Microsoft.Data.SqlClient` but not recognized by the `System.Data.SqlClient` provider that Kentico 13 uses internally — no longer cause the tool to throw. Unsupported keywords are silently dropped before the string is handed to Kentico, keeping the tool compatible with connection strings copied from newer sources.
- The existing individual-field flow is preserved unchanged when no CLI argument is passed and the user selects "Individual fields".

## How to test

1. Build the tool: `dotnet build src/XperienceCommunity.DatabaseAnonymizer.csproj`.
2. **CLI argument** — run with a full connection string, verify no prompts appear for server/user/password and (if `Initial Catalog` is included) no database selection either:

    ```powershell
    xperience-anonymizer --connection-string "Server=.;Database=MyDb;User Id=sa;Password=***"
    ```

    Also verify the `-c` short form and the `--connection-string=<value>` inline form work.
3. **Interactive connection string** — run `xperience-anonymizer` with no arguments, choose "Full connection string" at the first prompt, paste a connection string (input should be masked). Confirm the anonymization runs.
4. **Interactive individual fields (regression)** — run `xperience-anonymizer` with no arguments, choose "Individual fields", and confirm the flow behaves identically to before (data source → user → password → database selection).
5. **Unsupported keyword tolerance** — paste a connection string containing `Command Timeout=60;` and verify the tool no longer throws `Keyword not supported: 'command timeout'` and runs to completion.
6. **Database prompt skipping** — provide a connection string containing `Initial Catalog=MyDb` (or `Database=MyDb`) and verify the database selection prompt is skipped; omit it and verify the prompt is still shown.
